### PR TITLE
trim breaklines of generated messages

### DIFF
--- a/textGenerator.js
+++ b/textGenerator.js
@@ -1,4 +1,9 @@
 const got = require('got');
+ 
+function trimBreaklines(string) {
+  return string.replace(/^\s+|\s+$/g, '');;
+
+}
 
 async function generate(prompt) {
   if (process.env.OPENAI_SECRET_KEY) {
@@ -17,7 +22,10 @@ async function generate(prompt) {
     };
 
     const response = await got.post(url, { json: params, headers: headers }).json();
-    return response.choices[0].text;
+    const text = response.choices[0].text; 
+    const parsed = trimBreaklines(text);
+
+    return parsed;
   }
   return prompt;
 }


### PR DESCRIPTION
This pull request aims to solve a problem regarding with leading breaklines in generated messages.
Now a generated message looks like this one:

![Screenshot from 2023-01-07 13-23-48](https://user-images.githubusercontent.com/43180519/211150464-568256a6-fab9-4ae4-b62b-68050ac7f5eb.png)

With this small changes now it looks:
![Screenshot from 2023-01-07 13-25-00](https://user-images.githubusercontent.com/43180519/211150499-bb02c1ba-1c20-4938-bca6-ce59ec42c281.png)


